### PR TITLE
Undef conflicting macros from math.h

### DIFF
--- a/include/pyscience11/numpy.h
+++ b/include/pyscience11/numpy.h
@@ -8,6 +8,12 @@
 #pragma once
 #include <pybind11/pybind11.h>
 
+/* These macros are defined in math.h. */
+#undef isfinite
+#undef signbit
+#undef isinf
+#undef isnan
+
 namespace numpy11 {
 
 class numpy_module : public pybind11::module {


### PR DESCRIPTION
By compiling with By compiling with `clang++ -I/home/gael/.local/include/python3.5m -I/usr/include/python3.5m -std=c++11 -lpython3.5m pyscience11.cpp -o pyscience11` or with g++ with the same parameters, both compilers complained because some bindings conflict with macros defined in math.h. This commit fixes this.